### PR TITLE
Add classNotFoundException as throwable in log to get full stacktrace info

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -1569,8 +1569,8 @@ public class XQueryContext implements BinaryValueManager, Context {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("module " + module.getNamespaceURI() + " loaded successfully.");
             }
-        } catch (final ClassNotFoundException e) {
-            LOG.warn("module class " + moduleClass + " not found. Skipping...");
+        } catch (final ClassNotFoundException cnfe) {
+            LOG.warn("module class " + moduleClass + " not found. Skipping...", cnfe);
         }
         return module;
     }


### PR DESCRIPTION
Enhance logging pattern not to swallow exception information.

This could help users to pinpoint some classloader issue as discussed with #3004 

A couple of other log report still swallow such classNotFoundException. Please tell me if this is relevant to provide larger PR on this aspect. 